### PR TITLE
set up grid to mirror and show even numbers

### DIFF
--- a/identicon/lib/identicon.ex
+++ b/identicon/lib/identicon.ex
@@ -13,10 +13,11 @@ defmodule Identicon do
   def build_grid(%Identicon.Image{hex: hex} = image ) do
     hex
     |> Enum.chunk(3)
+    |> Enum.map(&mirror_row/1)
   end
 
   def mirror_row(row) do
-    [first, second] = row
+    [first, second | _tail] = row
     row ++ [second, first]
 
     # alternatively, with full list assignment

--- a/identicon/lib/identicon.ex
+++ b/identicon/lib/identicon.ex
@@ -8,6 +8,7 @@ defmodule Identicon do
     |> hash_input
     |> pick_color
     |> build_grid
+    |> filter_odd_squares
   end
 
   def build_grid(%Identicon.Image{hex: hex} = image ) do
@@ -28,6 +29,12 @@ defmodule Identicon do
     # alternatively, with full list assignment
     # [first, second, third] = row
     # [first, second, third, second, first]
+  end
+
+  def filter_odd_squares(%Identicon.Image{grid: grid} = _image) do
+    Enum.filter grid, fn({code, _index}) ->
+      rem(code, 2) == 0
+    end
   end
 
   def pick_color(image) do

--- a/identicon/lib/identicon.ex
+++ b/identicon/lib/identicon.ex
@@ -7,6 +7,12 @@ defmodule Identicon do
     input
     |> hash_input
     |> pick_color
+    |> build_grid
+  end
+
+  def build_grid(%Identicon.Image{hex: hex} = image ) do
+    hex
+    |> Enum.chunk(3)
   end
 
   def pick_color(image) do

--- a/identicon/lib/identicon.ex
+++ b/identicon/lib/identicon.ex
@@ -15,6 +15,15 @@ defmodule Identicon do
     |> Enum.chunk(3)
   end
 
+  def mirror_row(row) do
+    [first, second] = row
+    row ++ [second, first]
+
+    # alternatively, with full list assignment
+    # [first, second, third] = row
+    # [first, second, third, second, first]
+  end
+
   def pick_color(image) do
     %Identicon.Image{hex: [r, g, b | _tail]} = image
 

--- a/identicon/lib/identicon.ex
+++ b/identicon/lib/identicon.ex
@@ -11,9 +11,14 @@ defmodule Identicon do
   end
 
   def build_grid(%Identicon.Image{hex: hex} = image ) do
-    hex
-    |> Enum.chunk(3)
-    |> Enum.map(&mirror_row/1)
+    grid =
+      hex
+      |> Enum.chunk(3)
+      |> Enum.map(&mirror_row/1)
+      |> List.flatten
+      |> Enum.with_index
+
+    %Identicon.Image{image | grid: grid}
   end
 
   def mirror_row(row) do

--- a/identicon/lib/image.ex
+++ b/identicon/lib/image.ex
@@ -1,3 +1,3 @@
 defmodule Identicon.Image do
-  defstruct hex: nil, color: nil
+  defstruct hex: nil, color: nil, grid: nil
 end

--- a/notes.md
+++ b/notes.md
@@ -116,3 +116,8 @@ Pattern Matching first elements of array
 
 Tuples should be used whenever you want to explain that different values have
 different meanings rather than just sharing a list
+
+passing a reference to a function with map:
+    |> Enum.map(&mirror_row/1)
+      - if I have a function called mirror_row, use the one that takes 1 argument (/1)
+      - `&` then `function_name` then `/ #of arguments the function takes`


### PR DESCRIPTION
This adds in the numbered grid, reflecting a map for the squares we want to color in on the identicon:

```
iex(1)> Identicon.main("pizza")
[
  {124, 0},
  {242, 1},
  {242, 3},
  {124, 4},
  {94, 5},
  {194, 6},
  {194, 8},
  {94, 9},
  {160, 10},
  {250, 11},
  {250, 13},
  {160, 14},
  {2, 16},
  {2, 18},
  {106, 21},
  {106, 23}
]
```